### PR TITLE
Actualizar pasos post deploy

### DIFF
--- a/docs/developers/deployment/post-deployment.md
+++ b/docs/developers/deployment/post-deployment.md
@@ -49,7 +49,16 @@ title: Procedimiento Post-Deployment
 		#C.3. Dirección para refill automático de la wallet C.1.
 		export RONDA_REFILL_ORIGIN_ACCOUNT="0xa4ad4b5a84b25a6b254ac5e051980eeebbe6ba1f"
 
-* Cargarle *ether* a las mismas direcciones en **BFA** solicitandoló al canal de Telegram oficial: [https://t.me/bfatec](https://t.me/bfatec).
+* Cargar *ether* a las mismas direcciones en las testnets de Ethereum (Ropsten, Rinkeby, Goerli y Kovan):
+
+	- [**Ropsten**](https://faucet.dimensions.network/)
+	- [**Rinkeby**](https://faucet.rinkeby.io/)
+	- [**Goerli**](https://faucet.goerli.mudit.blog/)
+	- [**Kovan**](https://faucets.chain.link/)
+
+* Cargar *ether* a las mismas direcciones en **BFA** solicitandoló al canal de Telegram oficial: [https://t.me/bfatec](https://t.me/bfatec).
+
+
 
 **c. Procedimiento:** Se debe realizar una llamada a la API del *DIDI Server* mediante el siguiente comando (ejemplo de nuestro ambiente de *QA*):
 

--- a/docs/developers/deployment/post-deployment.md
+++ b/docs/developers/deployment/post-deployment.md
@@ -51,10 +51,12 @@ title: Procedimiento Post-Deployment
 
 * Cargar *ether* a las mismas direcciones en las testnets de Ethereum (Ropsten, Rinkeby, Goerli y Kovan):
 
-	- [**Ropsten**](https://faucet.dimensions.network/)
+	- [**Ropsten**](https://faucet.ropsten.be/)
 	- [**Rinkeby**](https://faucet.rinkeby.io/)
-	- [**Goerli**](https://faucet.goerli.mudit.blog/)
-	- [**Kovan**](https://faucets.chain.link/)
+	- [**Goerli**](https://goerli-faucet.slock.it/)
+	- [**Kovan**](https://gitter.im/kovan-testnet/faucet#)
+
+	Como opción alternativa se puede utilizar el faucet de Metamask - [https://faucet.metamask.io/](https://faucet.metamask.io/)
 
 * Cargar *ether* a las mismas direcciones en **BFA** solicitandoló al canal de Telegram oficial: [https://t.me/bfatec](https://t.me/bfatec).
 


### PR DESCRIPTION
- Se agregan a los pasos post deploy el paso de cargar las direcciones en las resdes de test de Ethereum.